### PR TITLE
FIX: Invalid signature generation

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -327,7 +327,7 @@ OAuth.prototype.prepareParameters = function (options) {
       try {
         parameters = JSON.parse(options.body);
       } catch (e) {
-        if (typeof query.parse(options.body) === "object") {
+        if (options.type.toLowerCase() === "application/x-www-form-urlencoded" && typeof query.parse(options.body) === "object") {
           parameters = utils.extend(parameters, query.parse(options.body));
         }
       }


### PR DESCRIPTION
This commit fixes an issue were the library is incorrectly normalizing and adding the request body when the content type is not form-encoded.  This results in an invalid signature being generated for the request.

The OAuth 1.0a specs states this about normalizing request parameters:

> 9.1.1.  Normalize Request Parameters
> 
> The request parameters are collected, sorted and concatenated into a normalized string:
> 
>- Parameters in the OAuth HTTP Authorization header excluding the realm parameter.
>- Parameters in the HTTP POST request body (**with a content-type of application/x-www-form-urlencoded**).
>- HTTP GET parameters added to the URLs in the query part (as defined by [RFC3986] section 3).

Source: [OAuth 1.0a Spec: Normalize Request Parameters](http://oauth.net/core/1.0a/#anchor13)

**[FIX]** Check the content type when preparing the signature parameters.