### PR TITLE
Added 1.0 as default version, reflecting the documentation.

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -48,7 +48,7 @@ var OAuth = module.exports = exports = function (options) {
   this.realm = options.realm || undefined;
   this.consumerKey = options.consumerKey;
   this.consumerSecret = utils.encodeData(options.consumerSecret);
-  this.version = options.version;
+  this.version = options.version || "1.0";
   this.signatureMethod = typeof options.signatureMethod === 'string' ? options.signatureMethod.toUpperCase() : undefined;
   this.nonceLength = options.nonceLength || options.nonceSize || 32;
   this.customTimestamp = options.timestamp || undefined;


### PR DESCRIPTION
The documentation states that the "version" argument is optional, and that "1.0" is the default. However, the library passes an emptry string as the version if it is not specified. This changed the default to "1.0".
