### PR TITLE
Change to using Object's hasOwnProperty

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,7 +22,7 @@ utils.extend = function (original, context) {
 utils.serialExtend = function (original, context, prefix) {
   var output = JSON.parse(JSON.stringify(original || {})), i, key, value;
   for (i in context) {
-    if (!context.hasOwnProperty(i)) continue;
+    if (!Object.prototype.hasOwnProperty.call(context, i)) continue;
     else key = prefix ? prefix + "[" + i + "]" : i, value = context[i];
     if (Object.prototype.toString.call(value) === '[object Object]')
       output = utils.serialExtend(output, value, key);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,7 @@ var utils = module.exports = exports = {
 utils.extend = function (original, context) {
   var output = JSON.parse(JSON.stringify(original || {})), key;
   for (key in context)
-    if (context.hasOwnProperty(key))
+    if (Object.prototype.hasOwnProperty.call(context, key))
       if (Object.prototype.toString.call(context[key]) === '[object Object]')
         output[key] = utils.extend(output[key] || {}, context[key]);
       else


### PR DESCRIPTION
querystring's parsed object does not inherit from `Object` so it does not get the `hasOwnProperty` method. This causes an error when passing a query string as `body`
